### PR TITLE
Use org_full_name

### DIFF
--- a/R/lesson_table.R
+++ b/R/lesson_table.R
@@ -23,6 +23,10 @@ build_lesson_table <- function(lesson_data) {
       github_topics = colDef(
         show = FALSE
       ),
+      org_full_name = colDef(
+        name = "Organisation",
+        filterable = TRUE
+      ),
       life_cycle_tag = colDef(
         name = "Life Cycle Stage",
         filterable = TRUE,
@@ -44,8 +48,7 @@ build_lesson_table <- function(lesson_data) {
         filterable = TRUE
       ),
       carpentries_org = colDef(
-        name = "Organisation",
-        filterable = TRUE
+        show = FALSE
       ),
       repo = colDef(
         name = "Repository",

--- a/R/lesson_table.R
+++ b/R/lesson_table.R
@@ -31,7 +31,7 @@ build_lesson_table <- function(lesson_data) {
         name = "Life Cycle Stage",
         filterable = TRUE,
         class = function(value) {
-          paste0("<p class='", value, "'>", value, "</p>")
+          paste0("life-cycle-", value)
         }
       ),
       lesson_tags = colDef(

--- a/script.R
+++ b/script.R
@@ -32,6 +32,7 @@ lesson_data <- lesson_data[, c(
   "repo",
   "life_cycle_tag",
   "lesson_tags",
+  "org_full_name",
   "carpentries_org",
   "repo_url",
   "full_name",


### PR DESCRIPTION
This should update the lesson table to include the full organisation name instead of the slug version. It also includes a small correction to the life cycle stage column, creating `life-cycle-pre-alpha`, `life-cycle-alpha`, etc classes that can be more easily styled in future.