### PR TITLE
add json of invalid hashes for workbench

### DIFF
--- a/.github/workflows/deploy-invalid-hash-list.yaml
+++ b/.github/workflows/deploy-invalid-hash-list.yaml
@@ -1,0 +1,29 @@
+name: Update List of Invalid Hashes in the Workbench
+
+on:
+  push:
+    branches: main
+
+jobs:
+  update-invalid-list:
+    if: github.repository_owner == 'carpentries'
+    runs-on: ubuntu-20.04
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: checkout the Repository
+        uses: actions/checkout@v2
+
+      - name: Deploy to AWS S3
+        id: deploy
+        uses: fmichonneau/s3-sync-action@log-output
+        with:
+          args: --acl public-read --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE_DIR: workbench/

--- a/workbench/invalid-hashes.json
+++ b/workbench/invalid-hashes.json
@@ -1,0 +1,4 @@
+{
+  "default" : "0000000000000000000000000000000000000000",
+  "carpentries/styles" : "e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4"
+}


### PR DESCRIPTION
When the workbench is launched, we will need to make sure that pull requests to lessons that have previously used the styles repositories do not accept commits from forks that were made prior to the transition. 

This action and json list will provide commits that should not exist in a branch history for a given lesson, which can be combined with https://github.com/carpentries/actions/pull/50 to to a pre-flight check on pull requests and instruct contributors that they need to delete their fork and re-fork.



