### PR TITLE
add invalidation hash from datacarpentry/R-ecology-lesson

### DIFF
--- a/workbench/invalid-hashes.json
+++ b/workbench/invalid-hashes.json
@@ -1,5 +1,7 @@
 {
   "default" : "0000000000000000000000000000000000000000",
   "carpentries/styles" : "e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4",
-  "zkamvar/bookish-giggle": "c26fdf32253acb5f03e3ebc75d8792309c1feb20"
+  "zkamvar/bookish-giggle" : "c26fdf32253acb5f03e3ebc75d8792309c1feb20",
+  "fishtree-attempt/R-ecology-lesson" : "b99f2de74d7d7f2ae62c3471bb8648a648c853ea",
+  "datacarpentry/R-ecology-lesson" : "b99f2de74d7d7f2ae62c3471bb8648a648c853ea"
 }


### PR DESCRIPTION
This will make sure that any pull request to the workbench version of R-ecology-lesson does not include [a non-lesson content commit from 2015](https://github.com/datacarpentry/r-ecology-lesson/tree/b99f2de74d7d7f2ae62c3471bb8648a648c853ea), which will prevent forks created from the original lesson from making a pull request that poisons the workbench version.