### PR TITLE
add r-socialsci invalid hash

### DIFF
--- a/workbench/invalid-hashes.json
+++ b/workbench/invalid-hashes.json
@@ -3,5 +3,6 @@
   "carpentries/styles" : "e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4",
   "zkamvar/bookish-giggle" : "c26fdf32253acb5f03e3ebc75d8792309c1feb20",
   "fishtree-attempt/R-ecology-lesson" : "b99f2de74d7d7f2ae62c3471bb8648a648c853ea",
-  "datacarpentry/R-ecology-lesson" : "b99f2de74d7d7f2ae62c3471bb8648a648c853ea"
+  "datacarpentry/R-ecology-lesson" : "b99f2de74d7d7f2ae62c3471bb8648a648c853ea",
+  "datacarpentry/r-socialsci" : "7d6cd0d8ce0526f07bcd9aa299f12cda5d3b7d4e"
 }


### PR DESCRIPTION
This adds the invalid hash for the transformation of r-socialsci to the workbench
