### PR TITLE
add dc/r-raster-vector-geospatial invalid hash

### DIFF
--- a/workbench/invalid-hashes.json
+++ b/workbench/invalid-hashes.json
@@ -4,5 +4,6 @@
   "zkamvar/bookish-giggle" : "c26fdf32253acb5f03e3ebc75d8792309c1feb20",
   "fishtree-attempt/R-ecology-lesson" : "b99f2de74d7d7f2ae62c3471bb8648a648c853ea",
   "datacarpentry/R-ecology-lesson" : "b99f2de74d7d7f2ae62c3471bb8648a648c853ea",
-  "datacarpentry/r-socialsci" : "7d6cd0d8ce0526f07bcd9aa299f12cda5d3b7d4e"
+  "datacarpentry/r-socialsci" : "7d6cd0d8ce0526f07bcd9aa299f12cda5d3b7d4e",
+  "datacarpentry/r-raster-vector-geospatial" : "757a195fc2c5a48bc002c2cf425e9345cb6ea0b9"
 }


### PR DESCRIPTION
This adds the invalidation hash for the workbench version of datacarpentry/r-raster-vector-geospatial
