### PR TITLE
ENH: Add invalid hash for `carpentries-incubator/SDC-BIDS-sMRI`

### DIFF
--- a/workbench/invalid-hashes.json
+++ b/workbench/invalid-hashes.json
@@ -62,5 +62,6 @@
   "carpentries-incubator/python-humanities-lesson": "d5206407b346c98a322cfb43de3af8e9f78678ce",
   "carpentries-incubator/SDC-BIDS-IntroMRI": "91446676f8d1011d17a47308feddaf5bbd75b694",
   "carpentries-incubator/SDC-BIDS-fMRI": "91446676f8d1011d17a47308feddaf5bbd75b694",
-  "carpentries-incubator/SDC-BIDS-dMRI": "91446676f8d1011d17a47308feddaf5bbd75b694"
+  "carpentries-incubator/SDC-BIDS-dMRI": "91446676f8d1011d17a47308feddaf5bbd75b694",
+  "carpentries-incubator/SDC-BIDS-sMRI": "cb8191e8d19c8734b863a11b31c8fd40fdcc74c8"
 }


### PR DESCRIPTION
Add invalid hash for `carpentries-incubator/SDC-BIDS-sMRI` after Workbench transition.
