### PR TITLE
Add invalid hash for carpentries-incubator/gap-lesson

### DIFF
--- a/workbench/invalid-hashes.json
+++ b/workbench/invalid-hashes.json
@@ -55,6 +55,7 @@
   "carpentries-incubator/bioc-intro" : "cd629438ff25e930eb4d52b06e8f530b1b6650ef",
   "carpentries-incubator/bioc-rnaseq" : "b13a45ec77a42f85edf5f6c1f8a341f072275f91",
   "carpentries-incubator/bioc-project" : "a8e8d10ba3c8ab745573ac939c24e949494938d7",
+  "carpentries-incubator/gap-lesson" : "b4fbb1fcd0f6850d57dfb6f0a136bc255ac1e900",
   "carpentries-incubator/good-enough-practices" : "b9c50160fbf5173f7c726d865774efeb774c582f",
   "carpentries/maintainter-onboarding" : "e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4",
   "carpentries/instructor-training": "b4fbb1fcd0f6850d57dfb6f0a136bc255ac1e900",


### PR DESCRIPTION
I have migrated https://github.com/carpentries-incubator/gap-lesson to Workbench, and now adding the invalid hash as suggested at https://carpentries.github.io/sandpaper-docs/migrating-from-styles.html#post-transition.

The instructions are to add it at the last line, but as far as I see you keep it ordered (this also avoids modifying the line preceding the newly added one, so will not confuse `git blame`).