### PR TITLE
Add python-intermediate-development

### DIFF
--- a/workbench/invalid-hashes.json
+++ b/workbench/invalid-hashes.json
@@ -57,7 +57,7 @@
   "carpentries-incubator/bioc-project" : "a8e8d10ba3c8ab745573ac939c24e949494938d7",
   "carpentries-incubator/gap-lesson" : "b4fbb1fcd0f6850d57dfb6f0a136bc255ac1e900",
   "carpentries-incubator/good-enough-practices" : "b9c50160fbf5173f7c726d865774efeb774c582f",
-  "carpentries/maintainter-onboarding" : "e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4",
+  "carpentries/maintainer-onboarding" : "e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4",
   "carpentries/instructor-training": "b4fbb1fcd0f6850d57dfb6f0a136bc255ac1e900",
   "carpentries/instructor-training-bonus-modules": "e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4",
   "carpentries-incubator/python-humanities-lesson": "d5206407b346c98a322cfb43de3af8e9f78678ce",
@@ -66,6 +66,7 @@
   "carpentries-incubator/SDC-BIDS-dMRI": "91446676f8d1011d17a47308feddaf5bbd75b694",
   "carpentries-incubator/SDC-BIDS-sMRI": "cb8191e8d19c8734b863a11b31c8fd40fdcc74c8",
   "carpentries-incubator/SDC-BIDS-EEG-EEGLAB": "91446676f8d1011d17a47308feddaf5bbd75b694",
+  "carpentries-incubator/python-intermediate-development": "e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4",
   "carpentries-lab/python-aos-lesson": "e83e2c9bdeb259fcb7b12ae21da8f6eac8ff34a4",
   "carpentries/trainer-training": "91446676f8d1011d17a47308feddaf5bbd75b694"
 }


### PR DESCRIPTION
Add the invalid hash for the python-intermediate-development lesson in the Carpentries Incubator. Also, a small typo fix to one of the keys for the other lessons.
